### PR TITLE
Fixing wrong path

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,6 @@
 module libmongoc {
-    header "/usr/local/include/libmongoc-1.0/mongoc.h"
+    header "/usr/include/libbson-1.0/bson.h"
+    header "/usr/include/libmongoc-1.0/mongoc.h"
     link "mongoc-1.0"
     export *
 }


### PR DESCRIPTION
The previous version of module.modulemap is using macOS path.